### PR TITLE
Fix for use with Windows paths

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -43,6 +43,7 @@ pem = "0.6"
 rand = "0.7"
 rsa = { git = "https://github.com/RustCrypto/RSA", rev = "11500ed" }
 hex = "0.3"
+path-slash = "0.1"
 
 [features]
 default = ["structopt", "cargo_metadata", "semver", "scroll", "goblin", "clap", "cargo-toml2"]

--- a/src/bin/main.rs
+++ b/src/bin/main.rs
@@ -15,6 +15,8 @@ use std::process::{Command, Stdio};
 use cargo_metadata::{Message, Package};
 use sprinkle::format::{nacp::NacpFile, nxo::NxoFile, romfs::RomFs, pfs0::Pfs0, npdm::NpdmJson, npdm::ACIDBehavior};
 
+use path_slash::PathBufExt;
+
 #[derive(Debug, Serialize, Deserialize, Default)]
 struct NspMetadata {
     npdm: String
@@ -70,7 +72,7 @@ fn main() {
     let rust_target_path = match env::var("RUST_TARGET_PATH") {
         Err(VarError::NotPresent) => metadata.workspace_root.clone(),
         s => PathBuf::from(s.unwrap()),
-    };
+    }.to_slash();
 
     let mut xargo_args: Vec<String> = vec![
         String::from("build"),
@@ -83,7 +85,7 @@ fn main() {
         xargo_args.push(arg);
     }
 
-    let target_path = ensure_target(rust_target_path.to_str().unwrap());
+    let target_path = ensure_target(&rust_target_path.unwrap());
 
     let mut command = Command::new("xargo");
     command.args(&xargo_args).stdout(Stdio::piped()).env("RUST_TARGET_PATH", target_path);


### PR DESCRIPTION
Fix the invalid JSON error on Windows.

Before:

```
→ C:\home\projects\examples\graphics\simple-window [master ≡ +1 ~1 -0 !]› sprinkle nsp
Building NSP sysmodule...
error: C:\home\projects\examples\graphics\simple-window/target\aarch64-none-elf.json is not valid JSON
caused by: invalid escape at line 18 column 26
note: run with `RUST_BACKTRACE=1` for a backtrace

→ C:\home\projects\examples\graphics\simple-window [master ≡ +1 ~1 -0 !]› $env:RUST_TARGET_PATH="C:\home\projects\examples\graphics\simple-window"; $env:RUSTFLAGS="-Z macro-backtrace"; sprinkle nsp
Building NSP sysmodule...
error: C:\home\projects\examples\graphics\simple-window/target\aarch64-none-elf.json is not valid JSON
caused by: invalid escape at line 18 column 26
note: run with `RUST_BACKTRACE=1` for a backtrace

→ C:\home\projects\examples\graphics\simple-window [master ≡ +2 ~1 -0 !]› $env:RUST_TARGET_PATH="C:/home/projects/examples/graphics/simple-window"; $env:RUSTFLAGS="-Z macro-backtrace"; sprinkle nsp
Building NSP sysmodule...
Writing main... [1/2]
Writing main.npdm... [2/2]
Built C:\home\projects\examples\graphics\simple-window\target\aarch64-none-elf\debug\simple-window.nsp
```

After:

```
→ C:\home\projects\examples\graphics\simple-window [master ≡ +2 ~1 -0 !]› ./sprinkle nsp
Building NSP sysmodule...
Writing main... [1/2]
Writing main.npdm... [2/2]
Built C:\home\projects\examples\graphics\simple-window\target\aarch64-none-elf\debug\simple-window.nsp

→ C:\home\projects\examples\graphics\simple-window [master ≡ +2 ~1 -0 !]› $env:RUST_TARGET_PATH="C:\home\projects\examples\graphics\simple-window"; $env:RUSTFLAGS="-Z macro-backtrace"; ./sprinkle nsp
Building NSP sysmodule...
Writing main... [1/2]
Writing main.npdm... [2/2]
Built C:\home\projects\examples\graphics\simple-window\target\aarch64-none-elf\debug\simple-window.nsp
```